### PR TITLE
言語情報がnullの場合の例外回避 + デフォルト値設定

### DIFF
--- a/src/com/github/hmdev/writer/Epub3Writer.java
+++ b/src/com/github/hmdev/writer/Epub3Writer.java
@@ -460,6 +460,7 @@ public class Epub3Writer
 		//刊行者情報
 		if (bookInfo.publisher != null) velocityContext.put("publisher", bookInfo.publisher);
 		//言語 &<>はエスケープ
+		if (bookInfo.language == null) bookInfo.language = "ja";
 		velocityContext.put("language", CharUtils.escapeHtml(bookInfo.language));
 
 		//書籍情報


### PR DESCRIPTION
外部からコマンドラインで利用する際に、メタ情報に言語項目が含まれていない場合にNullPointerExceptionが発生する問題を回避しました。
さらに、言語情報をnullにしたままepub出力し、そのepubをmobiに変換しようとするとkindlegenでE23006(dc:Languageフィールドは必須です)が発生するため、デフォルト値を設定しました。

この問題はAppletを起動して変換する場合には発生しません。なぜならコンボボックスによりデフォルトが"ja"とされているためです。
このPRではこのAppletの挙動にあわせてデフォルト値を"ja"としてハードコードしました。
オプションがあることが望ましいとは思いますが、需要は少なそうなので特に対応していません。