### PR TITLE
CI via GitHub Actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,26 @@
+name: Nightly Build
+on:
+  - push
+  - workflow_dispatch
+jobs:
+  build_artifacts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get version from source code.
+        run: |
+          >> $GITHUB_ENV echo PKG_VER=$(egrep 'VERSION\s+=' src/AozoraEpub3.java | awk -F '"' '{print $2}')
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'zulu'
+          cache: 'gradle'
+      - run: gradle build
+      - run: mkdir -p bin
+      - run: gradle create_run_jar
+      - run: cp -v build/libs/AozoraEpub3.jar out/
+      - run: cp -vr lib/LICENSE out/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: AozoraEpub3-${{ env.PKG_VER }}
+          path: out/

--- a/ant.xml
+++ b/ant.xml
@@ -5,7 +5,7 @@
     <!--define folder properties-->
     <property name="dir.buildfile" value="."/>
     <property name="dir.workspace" value="${dir.buildfile}/.."/>
-    <property name="dir.jarfile" value="C:/Users/Owner/Desktop/AozoraEpub3-1.1.1b19Q/"/>
+    <property name="dir.jarfile" value="./out"/>
     <target name="create_run_jar">
         <jar destfile="${dir.jarfile}/AozoraEpub3.jar">
             <manifest>

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ tasks.withType(JavaCompile) {
     options.compilerArgs << '-Xlint:unchecked'
 }
 */
+ant.importBuild 'ant.xml'
 
 dependencies {
 // https://mvnrepository.com/artifact/org.apache.velocity/velocity-engine-core


### PR DESCRIPTION
Build things using GitHub.

Tested by downloading an URL with it, works.

The artifact will left by [90 days](https://github.com/actions/upload-artifact#retention-period) default. It may need to re-upload them when making a release.