### PR TITLE
濁点結合の改修

### DIFF
--- a/src/com/github/hmdev/converter/AozoraEpub3Converter.java
+++ b/src/com/github/hmdev/converter/AozoraEpub3Converter.java
@@ -1757,7 +1757,7 @@ public class AozoraEpub3Converter
 			}
 		}
 
-		//割仲介し文字位置
+		//割り注開始文字位置
 		int wrcStart = 0;
 		//割り注の改行挿入位置
 		int wrcBrPos = -1;
@@ -2449,11 +2449,20 @@ public class AozoraEpub3Converter
 		String rubyEndChuki = chukiMap.get("ルビ終了")[0];
 
 		boolean noTcy = false;
+		boolean noTcyPre = noTcy;
 		for (int i=begin; i<end; i++) {
 
 			//縦中横と横書きの中かチェック
-			if (!noTcy && noTcyStart.contains(i)) noTcy = true;
-			else if (noTcy && noTcyEnd.contains(i)) noTcy = false;
+			if (!noTcy && noTcyStart.contains(i)) {
+				//未処理の文字列が残っていないなら noTcy と同じ値を設定。残っているなら noTcy の値を保存。
+				noTcyPre = (rubyStart == -1)? true : noTcy;
+				noTcy = true;
+			} else if (noTcy && noTcyEnd.contains(i)) {
+				//未処理の文字列が残っていないなら noTcy と同じ値を設定。残っているなら noTcy の値を保存。
+				noTcyPre = (rubyStart == -1)? false : noTcy;
+				noTcy = false;
+			}
+			assert rubyStart != -1 || noTcyPre == noTcy;
 
 			switch (ch[i]) {
 			case '｜':
@@ -2461,7 +2470,7 @@ public class AozoraEpub3Converter
 				if (!CharUtils.isEscapedChar(ch, i)) {
 					//前まで出力
 					if (rubyStart != -1) convertTcyText(buf, ch, rubyStart, i, noTcy);
-					rubyStart = i + 1;
+					rubyStart = i + 1; noTcyPre = noTcy;
 					inRuby = true;
 				}
 				break;
@@ -2520,7 +2529,7 @@ public class AozoraEpub3Converter
 						LogAppender.warn(lineNum, "ルビ開始文字無し");
 					}
 					inRuby = false;
-					rubyStart = -1;
+					rubyStart = -1; noTcyPre = noTcy;
 					rubyTopStart = -1;
 				}
 			} else {
@@ -2538,27 +2547,27 @@ public class AozoraEpub3Converter
 					}
 					if (charTypeChanged) {
 						// rubyStartから前までを出力
-						convertTcyText(buf, ch, rubyStart, i, noTcy);
-						rubyStart = -1; rubyCharType = RubyCharType.NULL;
+						convertTcyText(buf, ch, rubyStart, i, noTcyPre);
+						rubyStart = -1; noTcyPre = noTcy; rubyCharType = RubyCharType.NULL;
 					}
 				}
 				//ルビが終了したか開始されていない
 				if (rubyStart == -1) {
 					// ルビ中でなく漢字
 					if (CharUtils.isKanji(ch, i)) {
-						rubyStart = i; rubyCharType = RubyCharType.KANJI;
+						rubyStart = i; noTcyPre = noTcy; rubyCharType = RubyCharType.KANJI;
 					} else if (CharUtils.isHiragana(ch[i])) {
-						//全角英数字
-						rubyStart = i; rubyCharType = RubyCharType.HIRAGANA;
+						//ひらがな
+						rubyStart = i; noTcyPre = noTcy; rubyCharType = RubyCharType.HIRAGANA;
 					} else if (CharUtils.isKatakana(ch[i])) {
-						//全角英数字
-						rubyStart = i; rubyCharType = RubyCharType.KATAKANA;
+						//カタカナ
+						rubyStart = i; noTcyPre = noTcy; rubyCharType = RubyCharType.KATAKANA;
 					} else if (CharUtils.isHalfSpace(ch[i]) && ch[i]!='>') {
 						//英数字または空白
-						rubyStart = i; rubyCharType = RubyCharType.ALPHA;
+						rubyStart = i; noTcyPre = noTcy; rubyCharType = RubyCharType.ALPHA;
 					} else if (CharUtils.isFullAlpha(ch[i]) || CharUtils.isFullNum(ch[i])) {
 						//全角英数字
-						rubyStart = i; rubyCharType = RubyCharType.FULLALPHA;
+						rubyStart = i; noTcyPre = noTcy; rubyCharType = RubyCharType.FULLALPHA;
 					}
 					// ルビ中でなく漢字、半角以外は出力 数字と!?は英字扱いになっている
 					else {
@@ -2929,24 +2938,21 @@ public class AozoraEpub3Converter
 					if (CharUtils.isHiragana(ch[i]) || CharUtils.isKatakana(ch[i]) || ch[i]=='〻') {
 						//通常の濁点文字ならその文字で出力
 						if (ch[i+1]=='゛') {
-							if ('ッ' != ch[i] && ('か' <= ch[i] && ch[i] <= 'と' || 'カ' <= ch[i] && ch[i] <= 'ト')) {
-								ch[i] = (char)((int)ch[i]+1);
-								buf.append(ch[i]);
+							int pos = "うかきくけこさしすせそたちつてとはひふへほゝウカキクケコサシスセソタチツテトハヒフヘホワヰヱヲヽ".indexOf(ch[i]);
+							if (pos >= 0) {
+								char ch2 = "ゔがぎぐげござじずぜぞだぢづでどばびぶべぼゞヴガギグゲゴザジズゼゾダヂヅデドバビブベボヷヸヹヺヾ".charAt(pos);
+								buf.append(ch2);
 								i++;
 								continue;
 							}
-							if ('ウ' == ch[i]) { buf.append('ヴ'); i++; continue; }
-							if ('ワ' == ch[i]) { buf.append('ヷ'); i++; continue; }
-							if ('ヲ' == ch[i]) { buf.append('ヺ'); i++; continue; }
-							if ('う' == ch[i]) { buf.append('ゔ'); i++; continue; }
-							if ('ゝ' == ch[i]) { buf.append('ゞ'); i++; continue; }
-							if ('ヽ' == ch[i]) { buf.append('ヾ'); i++; continue; }
-						}
-						if ('は' <= ch[i] && ch[i] <= 'ほ' || 'ハ' <= ch[i] && ch[i] <= 'ホ') {
-							if (ch[i+1]=='゛') buf.append((char)((int)ch[i]+1));
-							else buf.append((char)((int)ch[i]+2));
-							i++;
-							continue;
+						} else if (ch[i+1]=='゜') {
+							int pos = "はひふへほハヒフヘホ".indexOf(ch[i]);
+							if (pos >= 0) {
+								char ch2 = "ぱぴぷぺぽパピプペポ".charAt(pos);
+								buf.append(ch2);
+								i++;
+								continue;
+							}
 						}
 						if (this.dakutenType == 1 && !(inYoko || noTcy)) {
 							//濁点をspanで重ねて表示 ルビ内無効

--- a/template/item/xhtml/title_middle.vm
+++ b/template/item/xhtml/title_middle.vm
@@ -17,8 +17,10 @@
 </head>
 
 
-
-<body class="p-titlepage">
+#if ($kindle)
+#set ($kindle_cls=" kindle")
+#end
+<body class="p-titlepage$!{kindle_cls}">
 <div class="main vrtl block-align-center">
 #if (${PUBLISHER})
 	<div class="publisher">${PUBLISHER}</div>

--- a/template/item/xhtml/xhtml_footer.vm
+++ b/template/item/xhtml/xhtml_footer.vm
@@ -1,5 +1,4 @@
-#if (${sectionInfo.Middle} || ${sectionInfo.bottom})
-</div>
+#if (${sectionInfo.Middle} || ${sectionInfo.Bottom})
 </div>
 #end
 </div>

--- a/template/item/xhtml/xhtml_header.vm
+++ b/template/item/xhtml/xhtml_header.vm
@@ -4,7 +4,7 @@
  xmlns="http://www.w3.org/1999/xhtml"
  xmlns:epub="http://www.idpf.org/2007/ops"
  xml:lang="ja"
-#if (${sectionInfo.ImagePage}  || ${sectionInfo.Middle})
+#if (${sectionInfo.ImagePage} || ${sectionInfo.Middle})
  class="hltr"
 #elseif (${bookInfo.Vertical})
  class="vrtl"
@@ -17,7 +17,6 @@
 <title>${title}</title>
 <link rel="stylesheet" type="text/css" href="../style/book-style.css"/>
 
-
 #if (${sectionInfo.ImageHeight} > 0)
 <style type="text/css">
 body .img img {
@@ -27,20 +26,29 @@ min-height: ${sectionInfo.ImageHeightPercent}%;
 </style>
 #end
 </head>
-
-#if ((${sectionInfo.ImageFitW}) || (${sectionInfo.ImageFitH}))
-<body class="p-image">
-#elseif ((${sectionInfo.Middle}) ||(${sectionInfo.Bottom}) )
-<body class="p-text">
-#else
-<body>
+#set ($body_class = "")
+#set ($sep = "")
+#if ($sectionInfo.ImageFitW || $sectionInfo.ImageFitH)
+#set ($body_class = "p-image")
+#set ($sep = " ")
+#elseif ($sectionInfo.Middle || $sectionInfo.Bottom)
+#set ($body_class = "p-text")
+#set ($sep = " ")
 #end
-<div class="main">
-#if (${sectionInfo.Middle})
+#if ($kindle)
+#set ($body_class = "$!{body_class}$!{sep}kindle")
+#set ($sep = " ")
+#end
+#if ($body_class != "")
+#set ($body_class = " class=""${body_class}""")
+#end
+<body$!{body_class}>
+#if ($sectionInfo.Middle)
 <div class="main vrtl block-align-center">
 <div class="start-2em">
-#end
-#if (${sectionInfo.Bottom})
+#elseif ($sectionInfo.Bottom)
 <div class="main vrtl block-align-end">
 <div class="start-2em">
+#else
+<div class="main">
 #end


### PR DESCRIPTION
本家から引き継いだ不具合の改修になります。
[濁点付き仮名 ＋ 濁点 が別な文字に置き換わる #17](https://github.com/hmdev/AozoraEpub3/issues/17)
[縦中横タグ前のテキストに濁点結合（重ねる）が適用されない #18](https://github.com/hmdev/AozoraEpub3/issues/18)

ただし、これをマージしても 18 のほうは、改造版のissue「kindle 変換で、濁点を「重ねる」位置が合っていない 17」を改修しないと、濁点の位置はおかしいままです。