### PR TITLE
URLコンストラクタの警告解決

### DIFF
--- a/src/AozoraEpub3Applet.java
+++ b/src/AozoraEpub3Applet.java
@@ -40,7 +40,9 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
-import java.net.URL;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLDecoder;
 import java.text.NumberFormat;
 import java.text.SimpleDateFormat;
@@ -404,7 +406,7 @@ public class AozoraEpub3Applet extends JFrame
 	}
 */
 	/** アプレット初期化 */
-	public void init()
+	public void init() throws MalformedURLException, URISyntaxException
 	{
 	//	super.init();
 		this.setSize(new Dimension(520, 460));
@@ -3864,7 +3866,7 @@ public class AozoraEpub3Applet extends JFrame
 	/** Web変換
 	 * @param vecUrlString 青空文庫テキストのzipまたは対応サイトのリンクURL
 	 * @param vecUrlSrcFile ショートカットファイルのURLならファイルが指定されている */
-	private void convertWeb(Vector<String> vecUrlString, Vector<File> vecUrlSrcFile, File dstPath) throws IOException
+	private void convertWeb(Vector<String> vecUrlString, Vector<File> vecUrlSrcFile, File dstPath) throws IOException, URISyntaxException
 	{
 		for (int i=0; i<vecUrlString.size(); i++) {
 			String urlString = vecUrlString.get(i);
@@ -3881,7 +3883,7 @@ public class AozoraEpub3Applet extends JFrame
 				LogAppender.println("出力先にダウンロードします : "+srcFile.getCanonicalPath());
 				srcFile.getParentFile().mkdirs();
 				//ダウンロード
-				BufferedInputStream bis = new BufferedInputStream(new URL(urlString).openStream(), 8192);
+				BufferedInputStream bis = new BufferedInputStream(new URI(urlString).toURL().openStream(), 8192);
 				BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(srcFile));
 				IOUtils.copy(bis, bos);
 				bos.close();
@@ -4747,8 +4749,9 @@ public class AozoraEpub3Applet extends JFrame
 	//	final AozoraEpub3Applet applet = new AozoraEpub3Applet(jFrame);
 		jFrame.setIconImage(new ImageIcon( AozoraEpub3Applet.class.getResource("images/icon.png")).getImage());
 		jFrame.setTitle("AozoraEpub3");
-		jFrame.init();
-
+		try {
+			jFrame.init();
+		} catch(Exception e) { e.printStackTrace(); }
 		//アイコン設定
 	//	jFrame.setIconImage(applet.iconImage);
 		//最小サイズ

--- a/src/com/github/hmdev/image/ImageUtils.java
+++ b/src/com/github/hmdev/image/ImageUtils.java
@@ -17,7 +17,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.net.URI;
 import java.util.Iterator;
 
 import javax.imageio.IIOImage;
@@ -83,7 +83,7 @@ public class ImageUtils
 		try {
 			InputStream is;
 			if (path.startsWith("http")) {
-				is = new BufferedInputStream(new URL(path).openStream(), 8192);
+				is = new BufferedInputStream(new URI(path).toURL().openStream(), 8192);
 			} else {
 				File file = new File(path);
 				if (!file.exists()) return null;

--- a/src/com/github/hmdev/swing/JConfirmDialog.java
+++ b/src/com/github/hmdev/swing/JConfirmDialog.java
@@ -11,9 +11,9 @@ import java.awt.event.ActionListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.File;
-import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Vector;
 
 import javax.swing.BorderFactory;
@@ -157,7 +157,7 @@ public class JConfirmDialog extends JDialog
 	//初回表示後true
 	boolean firstShown = false;
 	
-	public JConfirmDialog(Image iconImage, String imageURLPath)
+	public JConfirmDialog(Image iconImage, String imageURLPath) throws MalformedURLException, URISyntaxException
 	{
 		JButton jButton;
 		JPanel panel;
@@ -253,7 +253,7 @@ public class JConfirmDialog extends JDialog
 		jButtonTitle = new JButton("再取得");
 		jButtonTitle.setBorder(padding3);
 		jButtonTitle.setPreferredSize(new Dimension(72, 24));
-		try { jButtonTitle.setIcon(new ImageIcon(new URL(imageURLPath+"title_reload.png"))); } catch (MalformedURLException e1) {}
+		jButtonTitle.setIcon(new ImageIcon(new URI(imageURLPath+"title_reload.png").toURL()));
 		jButtonTitle.addActionListener(new ActionListener() {public void actionPerformed(ActionEvent arg0) { reloadTitle(); } });
 		panel.add(jButtonTitle);
 		panel.add(new JLabel("   "));
@@ -261,7 +261,7 @@ public class JConfirmDialog extends JDialog
 		jButtonTitleFileName.setToolTipText("ファイル名から設定");
 		jButtonTitleFileName.setBorder(BorderFactory.createEmptyBorder(3, 6, 3, 6));
 		jButtonTitleFileName.setPreferredSize(new Dimension(130, 24));
-		try { jButtonTitleFileName.setIcon(new ImageIcon(new URL(imageURLPath+"filename_copy.png"))); } catch (MalformedURLException e1) {}
+		jButtonTitleFileName.setIcon(new ImageIcon(new URI(imageURLPath+"filename_copy.png").toURL()));
 		jButtonTitleFileName.addActionListener(new ActionListener() { public void actionPerformed(ActionEvent arg0) { userFileName(); } });
 		panel.add(jButtonTitleFileName);
 		panel.add(new JLabel("     "));
@@ -347,7 +347,7 @@ public class JConfirmDialog extends JDialog
 		jButton = new JButton("変換実行");
 		jButton.setBorder(paddingButton);
 		jButton.setPreferredSize(new Dimension(80, 26));
-		try { jButton.setIcon(new ImageIcon(new URL(imageURLPath+"apply.png"))); } catch (MalformedURLException e1) {}
+		jButton.setIcon(new ImageIcon(new URI(imageURLPath+"apply.png").toURL()));
 		jButton.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				convert();
@@ -360,7 +360,7 @@ public class JConfirmDialog extends JDialog
 		jButton = new JButton("スキップ");
 		jButton.setBorder(paddingButton);
 		jButton.setPreferredSize(new Dimension(80, 26));
-		try { jButton.setIcon(new ImageIcon(new URL(imageURLPath+"skip.png"))); } catch (MalformedURLException e1) {}
+		jButton.setIcon(new ImageIcon(new URI(imageURLPath+"skip.png").toURL()));
 		jButton.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				skip();
@@ -375,7 +375,7 @@ public class JConfirmDialog extends JDialog
 		jButton = new JButton("処理中止");
 		jButton.setBorder(paddingButton);
 		jButton.setPreferredSize(new Dimension(80, 26));
-		try { jButton.setIcon(new ImageIcon(new URL(imageURLPath+"cancel.png"))); } catch (MalformedURLException e1) {}
+		jButton.setIcon(new ImageIcon(new URI(imageURLPath+"cancel.png").toURL()));
 		jButton.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				cancel();
@@ -504,7 +504,7 @@ public class JConfirmDialog extends JDialog
 		jButtonFirst.setPreferredSize(new Dimension(22, 22));
 		jButtonFirst.setToolTipText("先頭の画像");
 		jButtonFirst.setFocusable(false);
-		try { jButtonFirst.setIcon(new ImageIcon(new URL(imageURLPath+"first.png"))); } catch (MalformedURLException e1) {}
+		jButtonFirst.setIcon(new ImageIcon(new URI(imageURLPath+"first.png").toURL()));
 		jButtonFirst.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { movePreviewImage(-100000); }
@@ -515,7 +515,7 @@ public class JConfirmDialog extends JDialog
 		jButtonPrev.setPreferredSize(new Dimension(22, 22));
 		jButtonPrev.setToolTipText("前の画像 (PageUp)");
 		jButtonPrev.setFocusable(false);
-		try { jButtonPrev.setIcon(new ImageIcon(new URL(imageURLPath+"prev.png"))); } catch (MalformedURLException e1) {}
+		jButtonPrev.setIcon(new ImageIcon(new URI(imageURLPath+"prev.png").toURL()));
 		jButtonPrev.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { movePreviewImage(-1); }
@@ -526,7 +526,7 @@ public class JConfirmDialog extends JDialog
 		jButtonNext.setPreferredSize(new Dimension(22, 22));
 		jButtonNext.setToolTipText("次の画像 (PageDown)");
 		jButtonNext.setFocusable(false);
-		try { jButtonNext.setIcon(new ImageIcon(new URL(imageURLPath+"next.png"))); } catch (MalformedURLException e1) {}
+		jButtonNext.setIcon(new ImageIcon(new URI(imageURLPath+"next.png").toURL()));
 		jButtonNext.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { movePreviewImage(1); }
@@ -536,7 +536,7 @@ public class JConfirmDialog extends JDialog
 		/*jButtonFit = new JButton();
 		jButtonFit.setBorder(padding0);
 		jButtonFit.setPreferredSize(new Dimension(22, 22));
-		try { jButtonFit.setIcon(new ImageIcon(new URL(imageURL.toString()+"/arrow_out.png"))); } catch (MalformedURLException e1) {}
+		jButtonFit.setIcon(new ImageIcon(new URI(imageURL.toString()+"/arrow_out.png").toURL()));
 		jButtonFit.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { fitPreviewImage(JCoverImagePanel.FIT_ALL); }
@@ -547,7 +547,7 @@ public class JConfirmDialog extends JDialog
 		jButtonFitW.setPreferredSize(new Dimension(22, 22));
 		jButtonFitW.setToolTipText("画像の幅に拡大");
 		jButtonFitW.setFocusable(false);
-		try { jButtonFitW.setIcon(new ImageIcon(new URL(imageURLPath+"arrow_horizontal.png"))); } catch (MalformedURLException e1) {}
+		jButtonFitW.setIcon(new ImageIcon(new URI(imageURLPath+"arrow_horizontal.png").toURL()));
 		jButtonFitW.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { fitPreviewImage(JCoverImagePanel.FIT_W); }
@@ -558,7 +558,7 @@ public class JConfirmDialog extends JDialog
 		jButtonFitH.setPreferredSize(new Dimension(22, 22));
 		jButtonFitH.setToolTipText("画像の高さに拡大 (中ボタン)");
 		jButtonFitH.setFocusable(false);
-		try { jButtonFitH.setIcon(new ImageIcon(new URL(imageURLPath+"arrow_vertical.png"))); } catch (MalformedURLException e1) {}
+		jButtonFitH.setIcon(new ImageIcon(new URI(imageURLPath+"arrow_vertical.png").toURL()));
 		jButtonFitH.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { fitPreviewImage(JCoverImagePanel.FIT_H); }
@@ -590,7 +590,7 @@ public class JConfirmDialog extends JDialog
 		jButtonZoomIn.setPreferredSize(new Dimension(22, 22));
 		jButtonZoomIn.setToolTipText("画像を拡大 (ホイール)");
 		jButtonZoomIn.setFocusable(false);
-		try { jButtonZoomIn.setIcon(new ImageIcon(new URL(imageURLPath+"zoomin.png"))); } catch (MalformedURLException e1) {}
+		jButtonZoomIn.setIcon(new ImageIcon(new URI(imageURLPath+"zoomin.png").toURL()));
 		jButtonZoomIn.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { zoomPreview(1.01); }
@@ -603,7 +603,7 @@ public class JConfirmDialog extends JDialog
 		jButtonZoomOut.setPreferredSize(new Dimension(22, 22));
 		jButtonZoomOut.setToolTipText("画像を縮小 (ホイール)");
 		jButtonZoomOut.setFocusable(false);
-		try { jButtonZoomOut.setIcon(new ImageIcon(new URL(imageURLPath+"zoomout.png"))); } catch (MalformedURLException e1) {}
+		jButtonZoomOut.setIcon(new ImageIcon(new URI(imageURLPath+"zoomout.png").toURL()));
 		jButtonZoomOut.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { zoomPreview(1/1.01); }
@@ -631,7 +631,7 @@ public class JConfirmDialog extends JDialog
 		jButtonNarrow.setPreferredSize(new Dimension(22, 22));
 		jButtonNarrow.setToolTipText("表紙の幅を狭める (Ctrl+←、右ドラッグ)");
 		jButtonNarrow.setFocusable(false);
-		try { jButtonNarrow.setIcon(new ImageIcon(new URL(imageURLPath+"cover_narrow.png"))); } catch (MalformedURLException e1) {}
+		jButtonNarrow.setIcon(new ImageIcon(new URI(imageURLPath+"cover_narrow.png").toURL()));
 		jButtonNarrow.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { setVisibleWidthOffset(-1); }
@@ -644,7 +644,7 @@ public class JConfirmDialog extends JDialog
 		jButtonWide.setPreferredSize(new Dimension(22, 22));
 		jButtonWide.setToolTipText("表紙の幅を広げる (Ctrl+→、右ドラッグ)");
 		jButtonWide.setFocusable(false);
-		try { jButtonWide.setIcon(new ImageIcon(new URL(imageURLPath+"cover_wide.png"))); } catch (MalformedURLException e1) {}
+		jButtonWide.setIcon(new ImageIcon(new URI(imageURLPath+"cover_wide.png").toURL()));
 		jButtonWide.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { setVisibleWidthOffset(1); }
@@ -657,7 +657,7 @@ public class JConfirmDialog extends JDialog
 		jButtonCoverFull.setPreferredSize(new Dimension(22, 22));
 		jButtonCoverFull.setToolTipText("表紙の幅を元に戻す");
 		jButtonCoverFull.setFocusable(false);
-		try { jButtonCoverFull.setIcon(new ImageIcon(new URL(imageURLPath+"cover_full.png"))); } catch (MalformedURLException e1) {}
+		jButtonCoverFull.setIcon(new ImageIcon(new URI(imageURLPath+"cover_full.png").toURL()));
 		jButtonCoverFull.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { resetVisibleWidth(); }
@@ -675,7 +675,7 @@ public class JConfirmDialog extends JDialog
 		jButtonDelete.setPreferredSize(new Dimension(22, 22));
 		jButtonDelete.setToolTipText("表紙なし");
 		jButtonDelete.setFocusable(false);
-		try { jButtonDelete.setIcon(new ImageIcon(new URL(imageURLPath+"delete.png"))); } catch (MalformedURLException e1) {}
+		jButtonDelete.setIcon(new ImageIcon(new URI(imageURLPath+"delete.png").toURL()));
 		jButtonDelete.addActionListener(new ActionListener() {
 			@Override
 			public void actionPerformed(ActionEvent arg0) { deleteCover(); }

--- a/src/com/github/hmdev/swing/JProfileDialog.java
+++ b/src/com/github/hmdev/swing/JProfileDialog.java
@@ -9,7 +9,8 @@ import java.awt.Point;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
@@ -37,7 +38,7 @@ public class JProfileDialog extends JDialog
 	
 	String orgName = "";
 	
-	public JProfileDialog(Image iconImage, String imageURLPath)
+	public JProfileDialog(Image iconImage, String imageURLPath) throws MalformedURLException, URISyntaxException
 	{
 		this.setIconImage(iconImage);
 		this.setModalityType(Dialog.ModalityType.TOOLKIT_MODAL);
@@ -75,7 +76,7 @@ public class JProfileDialog extends JDialog
 		jButtonCreate = new JButton("新規作成");
 		jButtonCreate.setBorder(paddingButton);
 		//jButtonCreate.setPreferredSize(new Dimension(80, 26));
-		try { jButtonCreate.setIcon(new ImageIcon(new URL(imageURLPath+"add.png"))); } catch (MalformedURLException e1) {}
+		jButtonCreate.setIcon(new ImageIcon(new URI(imageURLPath+"add.png").toURL()));
 		jButtonCreate.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				if (linstener != null) linstener.actionPerformed(new ActionEvent(jTextProfileName.getText(), 1, "create"));
@@ -90,7 +91,7 @@ public class JProfileDialog extends JDialog
 		jButtonEdit = new JButton("名称変更");
 		jButtonEdit.setBorder(paddingButton);
 		//jButtonEdit.setPreferredSize(new Dimension(80, 26));
-		try { jButtonEdit.setIcon(new ImageIcon(new URL(imageURLPath+"edit.png"))); } catch (MalformedURLException e1) {}
+		jButtonEdit.setIcon(new ImageIcon(new URI(imageURLPath+"edit.png").toURL()));
 		jButtonEdit.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				if (linstener != null) linstener.actionPerformed(new ActionEvent(jTextProfileName.getText(), 2, "edit"));
@@ -105,7 +106,7 @@ public class JProfileDialog extends JDialog
 		jButtonDelete = new JButton("削除");
 		jButtonDelete.setBorder(paddingButton);
 		//jButtonDelete.setPreferredSize(new Dimension(80, 26));
-		try { jButtonDelete.setIcon(new ImageIcon(new URL(imageURLPath+"delete.png"))); } catch (MalformedURLException e1) {}
+		jButtonDelete.setIcon(new ImageIcon(new URI(imageURLPath+"delete.png").toURL()));
 		jButtonDelete.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				if (linstener != null) {
@@ -125,7 +126,7 @@ public class JProfileDialog extends JDialog
 		jButtonCancel = new JButton("キャンセル");
 		jButtonCancel.setBorder(paddingButton);
 		//jButtonCancel.setPreferredSize(new Dimension(80, 26));
-		try { jButtonCancel.setIcon(new ImageIcon(new URL(imageURLPath+"cross.png"))); } catch (MalformedURLException e1) {}
+		jButtonCancel.setIcon(new ImageIcon(new URI(imageURLPath+"cross.png").toURL()));
 		jButtonCancel.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
 				jTextProfileName.setText("");

--- a/src/com/github/hmdev/web/WebAozoraConverter.java
+++ b/src/com/github/hmdev/web/WebAozoraConverter.java
@@ -11,7 +11,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.HttpURLConnection;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLConnection;
 import java.text.SimpleDateFormat;
 import java.time.Instant;
@@ -216,7 +217,7 @@ public class WebAozoraConverter
 		if (!urlString.endsWith("/") && !urlString.endsWith(".html") && !urlString.endsWith(".htm") && urlString.indexOf("?") == -1 ) {
 			HttpURLConnection connection = null;
 			try {
-				connection = (HttpURLConnection) new URL(urlString+"/").openConnection();
+				connection = (HttpURLConnection) new URI(urlString+"/").toURL().openConnection();
 				if (connection.getResponseCode() == 200) {
 					urlString += "/";
 					LogAppender.println("URL修正 : "+urlString);
@@ -308,7 +309,7 @@ public class WebAozoraConverter
 			if (pagerele != null && pagerele.length > 0) pagerMax = pagerele[0].query;
 			LogAppender.println("ページャー最大値は"+pagerMax);
 			//LogAppender.println(String.valueOf(toc_index));
-					boolean pager = toc_index.isEmpty();
+					//boolean pager = toc_index.isEmpty();
 					boolean href = next_page.attr("href").isEmpty();
 					//link=n00000/?p=2
 					//baseUri=https://ncode.syosetu.com/
@@ -1291,7 +1292,7 @@ public class WebAozoraConverter
 
 	////////////////////////////////////////////////////////////////
 	/** htmlをキャッシュ すでにあれば何もしない */
-	private boolean cacheFile(String urlString, File cacheFile, String referer) throws IOException
+	private boolean cacheFile(String urlString, File cacheFile, String referer) throws IOException, URISyntaxException
 	{
 		//if (!replace && cacheFile.exists()) return false;
 		try { if (cacheFile.isDirectory()) cacheFile.delete(); } catch (Exception e) {} //空のディレクトリなら消す
@@ -1303,7 +1304,7 @@ public class WebAozoraConverter
 		}
 		cacheFile.getParentFile().mkdirs();
 		//ダウンロード
-		URLConnection conn = new URL(urlString).openConnection();
+		URLConnection conn = new URI(urlString).toURL().openConnection();
 		ExtractInfo[] cookie = this.queryMap.get(ExtractId.COOKIE);
 		if (cookie != null && cookie.length > 0) conn.setRequestProperty("Cookie", cookie[0].query);
 		if (referer != null) conn.setRequestProperty("Referer", referer);

--- a/src/com/github/hmdev/writer/Epub3Writer.java
+++ b/src/com/github/hmdev/writer/Epub3Writer.java
@@ -15,7 +15,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
-import java.net.URL;
+import java.net.URI;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
 import java.util.HashSet;
@@ -603,7 +603,7 @@ public class Epub3Writer
 				}
 				BufferedInputStream bis;
 				if (bookInfo.coverFileName.startsWith("http")) {
-					bis = new BufferedInputStream(new URL(bookInfo.coverFileName).openStream(), 8192);
+					bis = new BufferedInputStream(new URI(bookInfo.coverFileName).toURL().openStream(), 8192);
 				} else {
 					bis = new BufferedInputStream(new FileInputStream(new File(bookInfo.coverFileName)), 8192);
 				}


### PR DESCRIPTION
Fix URL constructor warning

### 主な修正

「JDK 20 - URL パブリック コンストラクターの非推奨化[^1]」の対応のため
`new URL(引数)` ⇒ `new URI(引数).toURL()` の置き換えを施しました。
下の参考ページにも書いてありますが、URIクラスと toURL メソッドは
もともと Java SE 1.0 [^2] の頃からあったようです。

参考ページ
(1) https://logico-jp.io/2023/02/20/quality-outreach-heads-up-jdk-20-deprecate-url-public-constructors/
(2) [JDK 20 – Deprecate URL Public Constructors](https://inside.java/2023/02/15/quality-heads-up/)

なお、URI のコンストラクタと toURL メソッドは例外を発生させる恐れがあります。
例外を拾う場所は、現行と同じか呼び出し元で拾うようにしました。

[^1]: URLクラスが非推奨なったわけではなく、コンストラクタが非推奨になった
[^2]: とりあえず SE 1.4 の Java doc で確認
https://docs.oracle.com/javase/jp/1.4/api/java/net/URI.html

### その他の修正

JConfirmDialog.java
14行目 `import java.io.IOException;`
は未使用のため、削除

WebAozoraConverter.java
311行目 `boolean pager = toc_index.isEmpty();`
は未使用のため、コメントアウト
