### PR TITLE
junrar他の廃止メソッドの最新化

### DIFF
--- a/src/com/github/hmdev/writer/Epub3ImageWriter.java
+++ b/src/com/github/hmdev/writer/Epub3ImageWriter.java
@@ -87,8 +87,7 @@ public class Epub3ImageWriter extends Epub3Writer
 			try {
 			for (FileHeader fileHeader : archive.getFileHeaders()) {
 				if (!fileHeader.isDirectory()) {
-					String entryName = fileHeader.getFileNameW();
-					if (entryName.length() == 0) entryName = fileHeader.getFileNameString();
+					String entryName = fileHeader.getFileName();
 					entryName = entryName.replace('\\', '/');
 					//アーカイブ内のサブフォルダは除外
 					String srcImageFileName = entryName.substring(archivePathLength);
@@ -106,7 +105,7 @@ public class Epub3ImageWriter extends Epub3Writer
 			ZipArchiveInputStream zis = new ZipArchiveInputStream(new BufferedInputStream(new FileInputStream(srcFile), 65536), "MS932", false);
 			try {
 			ArchiveEntry entry;
-			while( (entry = zis.getNextZipEntry()) != null ) {
+			while( (entry = zis.getNextEntry()) != null ) {
 				//アーカイブ内のサブフォルダは除外
 				String srcImageFileName = entry.getName().substring(archivePathLength);
 				this.writeArchiveImage(srcImageFileName, zis);

--- a/src/com/github/hmdev/writer/Epub3Writer.java
+++ b/src/com/github/hmdev/writer/Epub3Writer.java
@@ -888,8 +888,7 @@ public class Epub3Writer
 				try {
 				for (FileHeader fileHeader : archive.getFileHeaders()) {
 					if (!fileHeader.isDirectory()) {
-						String entryName = fileHeader.getFileNameW();
-						if (entryName.length() == 0) entryName = fileHeader.getFileNameString();
+						String entryName = fileHeader.getFileName();
 						entryName = entryName.replace('\\', '/');
 						//アーカイブ内のサブフォルダは除外してテキストからのパスにする
 						String srcImageFileName = entryName.substring(archivePathLength);
@@ -910,7 +909,7 @@ public class Epub3Writer
 				ZipArchiveInputStream zis = new ZipArchiveInputStream(new BufferedInputStream(new FileInputStream(srcFile), 65536), "MS932", false);
 				try {
 				ArchiveEntry entry;
-				while( (entry = zis.getNextZipEntry()) != null ) {
+				while( (entry = zis.getNextEntry()) != null ) {
 					//アーカイブ内のサブフォルダは除外してテキストからのパスにする
 					String srcImageFileName = entry.getName().substring(archivePathLength);
 					if (outImageFileNames.contains(srcImageFileName)) {


### PR DESCRIPTION
### 非推奨メソッド junrarライブラリ／getFileNameW, getFileNameString について
rarファイル内のファイル名を取得する際、現行コードでは、まず `getFileNameW` を呼び出して Unicode のファイル名の取得を試みます。それが失敗したら `getFileNameString` で ASCII コードのファイル名を取得します。

https://github.com/kyukyunyorituryo/AozoraEpub3/blob/82ac2046c88954798b17c0038485a3f7aad3215f/src/com/github/hmdev/image/ImageInfoReader.java#L260-L261

[junrar 7.5.5 API](https://javadoc.io/doc/com.github.junrar/junrar/latest/com/github/junrar/rarfile/FileHeader.html) の資料によれば、このような処理は `getFileName` のひとつの呼び出しに置き換えられます。

| Method | Returns | Status |
|----|----|----|
|[getFileNameW](https://javadoc.io/doc/com.github.junrar/junrar/latest/com/github/junrar/rarfile/FileHeader.html#getFileNameW())           | the Unicode filename, or null if the filename is ASCII only | 廃止 As of 7.2.0, replaced by getFileName() |
|[getFileNameString](https://javadoc.io/doc/com.github.junrar/junrar/latest/com/github/junrar/rarfile/FileHeader.html#getFileNameString()) | the ASCII filename. | 廃止 As of 7.2.0, replaced by getFileName() |
|[getFileName](https://javadoc.io/doc/com.github.junrar/junrar/latest/com/github/junrar/rarfile/FileHeader.html#getFileName()) | **the Unicode filename if it exists, else the ASCII filename** |推奨 |


### 非推奨メソッド apacheライブラリ／getNextZipEntry について

JavaDoc [Class ZipArchiveInputStream](https://commons.apache.org/proper/commons-compress/apidocs/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.html#getNextEntry()) には `getNextZipEntry` を `getNextEntry` に置き換えるよう書かれています

| Method | Returns | Status |
|----|----|----|
| [getNextZipEntry](https://commons.apache.org/proper/commons-compress/apidocs/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.html#getNextZipEntry()) | the next entry. | 廃止 Use getNextEntry |
| [getNextEntry](https://commons.apache.org/proper/commons-compress/apidocs/org/apache/commons/compress/archivers/zip/ZipArchiveInputStream.html#getNextEntry()) | the next entry, or null if there are no more entries. | 推奨 |

### zf がクローズされていないという警告の対応
下記 `ImageInfoReader.java` の [366行目](https://github.com/kyukyunyorituryo/AozoraEpub3/blob/82ac2046c88954798b17c0038485a3f7aad3215f/src/com/github/hmdev/image/ImageInfoReader.java#L361-L378) で `return null` が実行されるとき `zf` がクローズされないと警告されてました。

```java
 ZipFile zf = new ZipFile(this.srcFile, "MS932");
 ZipArchiveEntry entry = zf.getEntry(srcImageFileName);
 if (entry == null) {
     srcImageFileName = this.correctExt(srcImageFileName);
     entry = zf.getEntry(srcImageFileName);
     if (entry == null) return null;  //<----------ここでリターンする際、zf がクローズされない
 }
 InputStream is = zf.getInputStream(entry);
 try {
     return ImageUtils.readImage(srcImageFileName.substring(srcImageFileName.last...
 } catch (Exception e) {
     e.printStackTrace();
 } finally {
     is.close();
     zf.close();
 }
```

[InputStream](https://docs.oracle.com/javase/jp/8/docs/api/java/io/InputStream.html)クラスはもちろん apache の [ZipFile](https://commons.apache.org/proper/commons-compress/apidocs/org/apache/commons/compress/archivers/zip/ZipFile.html) クラスも `java.io.Closeable` を実装しているので `try-with-resources` 文を使えます。それを使うように修正しました。

ここの処理は「変換前確認」の画面で動きます。以下のとおり動作確認しました。
1. 画面右下のチェックボックス「変換前確認」をオンにする
2. 画像の格納されたZIP圧縮ファイルを画面にドラッグ＆ドロップする
3. 変確認画面の右側の画像エディタで次の画像に切り替え、画像が切り替わるか確認する。

### 非推奨メソッド getCount() の対応は見送り
getCountメソッドでもDeprecatedの警告が出てますが、もう少し調査します。今回は修正を見送ります。
