### PR TITLE
廃止メソッド（getCount）および未使用プロパティ（ImageInfo#ZipIndex）削除

### DIFF
--- a/src/com/github/hmdev/image/ImageInfoReader.java
+++ b/src/com/github/hmdev/image/ImageInfoReader.java
@@ -232,7 +232,7 @@ public class ImageInfoReader
 			if (lowerName.endsWith(".png") || lowerName.endsWith(".jpg") || lowerName.endsWith(".jpeg") || lowerName.endsWith(".gif")) {
 				ImageInfo imageInfo = null;
 				try {
-					imageInfo = ImageInfo.getImageInfo(zis, zis.getCount());
+					imageInfo = ImageInfo.getImageInfo(zis);
 				} catch (Exception e) {
 					LogAppender.error("画像が読み込めませんでした: "+srcFile.getPath());
 					e.printStackTrace();

--- a/src/com/github/hmdev/info/ImageInfo.java
+++ b/src/com/github/hmdev/info/ImageInfo.java
@@ -33,9 +33,6 @@ public class ImageInfo
 	/** 出力画像高さ */
 	int outHeight = -1;
 	
-	/** Zip内ファイルentryの位置 */
-	int zipIndex = -1;
-	
 	/** カバー画像ならtrue */
 	boolean isCover;
 	
@@ -44,36 +41,26 @@ public class ImageInfo
 	
 	/** 画像の情報を生成
 	 * @param ext png jpg gif の文字列 */
-	public ImageInfo(String ext, int width, int height, int zipIndex)
+	public ImageInfo(String ext, int width, int height)
 	{
 		super();
 		this.ext = ext.toLowerCase();
 		this.width = width;
 		this.height = height;
-		this.zipIndex = zipIndex;
 	}
 	
 	/** ファイルから画像情報を生成 */
 	static public ImageInfo getImageInfo(File imageFile) throws IOException
 	{
 		BufferedInputStream bis = new BufferedInputStream(new FileInputStream(imageFile));
-		ImageInfo imageInfo = ImageInfo.getImageInfo(bis, -1);
+		ImageInfo imageInfo = ImageInfo.getImageInfo(bis);
 		bis.close();
 		return imageInfo;
 	}
 	
-	/** 画像ストリームから画像情報を生成 */
-	static public ImageInfo getImageInfo(InputStream is) throws IOException
-	{
-		return getImageInfo(is, -1);
-	}
-	
-	
-	
 	/** 画像ストリームから画像情報を生成
-	 * @param zipIndex Zipファイルの場合はエントリの位置 (再読込や読み飛ばし時のファイル名比較の省略用)
 	 * @throws IOException */
-	static public ImageInfo getImageInfo(InputStream is, int zipIndex) throws IOException
+	static public ImageInfo getImageInfo(InputStream is) throws IOException
 	{
 		ImageInfo imageInfo = null;
 		ImageInputStream iis = ImageIO.createImageInputStream(is);
@@ -83,15 +70,15 @@ public class ImageInfo
 			if (readers.hasNext() && reader.getClass().getName().endsWith("CLibPNGImageReader")) readers.next();
 			reader.setInput(iis);
 			String ext = reader.getFormatName();
-			imageInfo = new ImageInfo(ext, reader.getWidth(0), reader.getHeight(0), zipIndex);
+			imageInfo = new ImageInfo(ext, reader.getWidth(0), reader.getHeight(0));
 			reader.dispose();
 		}
 		return imageInfo;
 	}
 	
-	static public ImageInfo getImageInfo(String ext, BufferedImage image, int zipIndex) throws IOException
+	static public ImageInfo getImageInfo(String ext, BufferedImage image) throws IOException
 	{
-		return new ImageInfo(ext, image.getWidth(), image.getHeight(), zipIndex);
+		return new ImageInfo(ext, image.getWidth(), image.getHeight());
 	}
 	
 	public String getId()
@@ -169,14 +156,5 @@ public class ImageInfo
 	public void setOutHeight(int outHeight)
 	{
 		this.outHeight = outHeight;
-	}
-	
-	public int getZipIndex()
-	{
-		return zipIndex;
-	}
-	public void setZipIndex(int zipIndex)
-	{
-		this.zipIndex = zipIndex;
 	}
 }

--- a/src/com/github/hmdev/writer/Epub3Writer.java
+++ b/src/com/github/hmdev/writer/Epub3Writer.java
@@ -642,7 +642,7 @@ public class Epub3Writer
 				if (imageInfo != null) ext = imageInfo.getExt();
 			}
 			if (isKindle || ext.equals("jpeg")) ext = "jpg";
-			coverImageInfo = ImageInfo.getImageInfo(ext, bookInfo.coverImage, -1);
+			coverImageInfo = ImageInfo.getImageInfo(ext, bookInfo.coverImage);
 			coverImageInfo.setId("0000");
 			coverImageInfo.setOutFileName("0000."+ext);
 			coverImageInfo.setIsCover(true);


### PR DESCRIPTION
Remove deprecated ZipArchiveInputStream#getCount method and unused ImageInfo#ZipIndex property.

廃止された ZipArchiveInputStream#getCount メソッドの警告を解消しました。
修正前のプログラムでは getCount の戻り値は最終的に ImageInfo のコンストラクタに渡され、ZipIndexプロパティに設定されます。
しかし、このプロパティは、ソースコードでもテンプレートでも使われていません。
リファクタリングも兼ね、getCountの呼び出しとZipIndexプロパティを削除しました。

### (参考) 動作確認の手順

#### 1. Epub3Writer.java の645行目
入力テキストファイル例
```
画像物語
にんじん
［＃画像（test.png）入る］

むかしむかし
```

表紙: 10 行目までの [先頭の挿絵]
変換前確認: ON
（注意）変換前確認画面で縮尺を変えるなどして図形を編集する必要があります


#### 2. ImageInfoReader.java の235行目

jpgやpngの画像を格納したフォルダを圧縮してドラッグ＆ドロップ
